### PR TITLE
Defaulting to general color when event type is unlisted.

### DIFF
--- a/src/components/static/live/schedule/Event.jsx
+++ b/src/components/static/live/schedule/Event.jsx
@@ -18,7 +18,7 @@ const colors = {
 };
 
 const Event = ({ event }) => {
-  const color = colors[event.category];
+  const color = colors[event.category] ?? colors['general'];
 
   return (
     <div className="w-full">


### PR DESCRIPTION
Right now on the prod site, when you click on Sunday the page crashes, this is because there is an error in the naming convention on the "Open-Floor Project Showcase" event. This is a band-aid patch to get the site working again, but the broken event should otherwise be updated.